### PR TITLE
fixed TypeError in newer Python versions

### DIFF
--- a/src/senti_classifier/senti_classifier.py
+++ b/src/senti_classifier/senti_classifier.py
@@ -227,8 +227,8 @@ def classify(text, synsets_scores, bag_of_words):
 #==========  Skipping pickle for a while  ==========*/
 
 # temporary fix for "no module named collections" error in some cases due to unexpected \r in .p files
-senti_pickle = resource_stream('senti_classifier', 'data/SentiWn.p').read().replace('\r', '')
-bag_of_words_pickle = resource_stream('senti_classifier', 'data/bag_of_words.p').read().replace('\r', '')
+senti_pickle = resource_stream('senti_classifier', 'data/SentiWn.p').read().replace(b'\r', b'')
+bag_of_words_pickle = resource_stream('senti_classifier', 'data/bag_of_words.p').read().replace(b'\r', b'')
 synsets_scores = pickle.loads(senti_pickle)
 bag_of_words = pickle.loads(bag_of_words_pickle)
 # #


### PR DESCRIPTION
[TypeError: a bytes-like object is required, not 'str'] while replacing the \r in the pickle file. So ended up using b'\r' to fix the issue.

Thanks, @[medasuryatej](https://github.com/medasuryatej) for pointing this out!

Edit: this indirectly addresses #17